### PR TITLE
Treat errors as app insights exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Then you didn't specify a suitable instrumentation key. See the section above.
 
 * **level**: lowest logging level transport to be logged (default: `info`)
 * **silent**: Boolean flag indicating whether to suppress output (default: `false`)
+* **treatErrorsAsExceptions**: Boolean flag indicating whether to treat errors as exceptions. 
+See section below for more details (default: `false`).
 
 **SDK integration options (required):**
 
@@ -110,3 +112,17 @@ silly          | verbose (0)
 
 [0]: https://azure.microsoft.com/en-us/services/application-insights/
 [1]: https://github.com/flatiron/winston
+
+## Treating errors as exceptions
+
+You can set the option `treatErrorsAsExceptions` when configuring the transport to treat errors as app insights exceptions for log levels >= `error` (defaults to `false`).
+
+This allows you to see it clearly in the Azure Application Insights instead of having to access trace information manually and set up alerts based on the related metrics.
+
+How it works:
+
+* `winstonLogger.log('error', 'error message');` will trigger an app insights `trackException` with `Error('error message')` as argument
+
+* `winstonLogger.log('error', new Error('error message'));` will trigger an app insights `trackException` with the Error object as argument
+
+* `winstonLogger.log('error', 'error message', new Error('error message'));` will trigger an app insights `trackException` with the Error object as argument

--- a/lib/winston-azure-application-insights.js
+++ b/lib/winston-azure-application-insights.js
@@ -71,6 +71,7 @@ var AzureApplicationInsightsLogger = function (options) {
 	this.name = WINSTON_LOGGER_NAME;
 	this.level = options.level || WINSTON_DEFAULT_LEVEL;
 	this.silent = options.silent || DEFAULT_IS_SILENT;
+	this.treatErrorsAsExceptions = !!options.treatErrorsAsExceptions;
 	
 	// Setup AI here!
 };
@@ -108,6 +109,22 @@ AzureApplicationInsightsLogger.prototype.log = function (level, msg, meta, callb
 		return callback(null, true); 
 	} 
 
+	var aiLevel = getMessageLevel(level);
+	
+	if (this.treatErrorsAsExceptions) {
+		if (aiLevel >= getMessageLevel('error')) {
+			var error;
+			if (msg instanceof Error) {
+				error = msg;
+			} else if (meta instanceof Error) {
+				error = meta;
+			} else {
+				error = Error(msg);
+			}
+			this.client.trackException(error);
+		}
+	}
+
 	if (meta instanceof Error) {
 		var errorMeta = {
 			stack: meta.stack,
@@ -128,10 +145,9 @@ AzureApplicationInsightsLogger.prototype.log = function (level, msg, meta, callb
 		meta = errorMeta;
 	}
 
-	this.client.trackTrace(msg, getMessageLevel(level), meta);
+	this.client.trackTrace(msg, aiLevel, meta);
 	
 	return callback(null, true);
 };
 
 exports.AzureApplicationInsightsLogger = AzureApplicationInsightsLogger;
- 


### PR DESCRIPTION
When the log level is >= `error`, the transport will also treat it as an app insights Exception.
This allows you to see it clearly in the Azure Application Insights instead of having to access trace information manually and set up alerts based on the related metrics.

How it works:
- `winstonLogger.log('error', 'error message');` will trigger an app insights `trackException` with `Error('error message')` as argument
- `winstonLogger.log('error', new Error('error message'));` will trigger an app insights `trackException` with the Error object as argument
- `winstonLogger.log('error', 'error message', new Error('error message'));` will trigger an app insights `trackException` with the Error object as argument
