### PR TITLE
update application insights version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "sinon": "^1.17.6"
   },
   "dependencies": {
-    "applicationinsights": "^0.15.8",
+    "applicationinsights": "^0.17.0",
     "winston": "^2.1.1"
   },
   "bugs": {


### PR DESCRIPTION
App Insights has stopped accepting telemetry by http. Need to update the version to at least 0.16.0 to get https support.  Current version is 0.17.0