### PR TITLE
pass meta on exception

### DIFF
--- a/lib/winston-azure-application-insights.js
+++ b/lib/winston-azure-application-insights.js
@@ -117,10 +117,11 @@ AzureApplicationInsightsLogger.prototype.log = function (level, msg, meta, callb
 			error = msg;
 		} else if (meta instanceof Error) {
 			error = meta;
+			meta = {};
 		} else {
 			error = Error(msg);
 		}
-		this.client.trackException(error);
+		this.client.trackException(error, meta);
 	}
 	else
 	{


### PR DESCRIPTION
The current code eats the supplied meta object in trackExecption cases.  This change tweaks handling to preserve the meta object (if supplied) and pass it as an AppInsights "properties" object.