### PR TITLE
Formatter support

### DIFF
--- a/lib/winston-azure-application-insights.js
+++ b/lib/winston-azure-application-insights.js
@@ -33,6 +33,20 @@ function getMessageLevel(winstonLevel) {
 	return winstonLevel in levels ? levels[winstonLevel] : levels.info;
 }
 
+exports.getMessageLevel = getMessageLevel;
+
+/**
+ * Default formatter
+ * @param {string} trackMethodName - trackTrace or trackException
+ * @param {string} userLevel - the level that the log method was called with (note this is NOT the AI level!)
+ * @param {{}} options - options that trackMethodName is called with (message, properties, meta, etc)
+ * @returns {{}} - updated options
+ */
+function defaultFormatter(trackMethodName, userLevel, options) {
+	return options;
+}
+
+exports.defaultFormatter = defaultFormatter;
 
 var AzureApplicationInsightsLogger = function (options) {
 
@@ -76,9 +90,7 @@ var AzureApplicationInsightsLogger = function (options) {
 	if (typeof options.formatter === 'function') {
 		this.formatter = options.formatter;
 	} else {
-		this.formatter = function noopFormatter(msg) {
-			return msg;
-		};
+		this.formatter = defaultFormatter;
 	}
 
 	// Setup AI here!
@@ -134,10 +146,12 @@ AzureApplicationInsightsLogger.prototype.log = function (level, msg, meta, callb
 		if (typeof msg === 'string') {
 			properties.message = msg;
 		}
-		this.client.trackException({
-			exception: error,
-			properties: properties,
-		});
+		this.client.trackException(
+			this.formatter('trackException', level, {
+				exception: error,
+				properties: properties,
+			})
+		);
 	}
 	else {
 		if (meta instanceof Error) {
@@ -160,11 +174,13 @@ AzureApplicationInsightsLogger.prototype.log = function (level, msg, meta, callb
 			meta = errorMeta;
 		}
 
-		this.client.trackTrace({
-			message: this.formatter(msg),
-			severity: aiLevel,
-			properties: meta,
-		});
+		this.client.trackTrace(
+			this.formatter('trackTrace', level, {
+				message: msg,
+				severity: aiLevel,
+				properties: meta,
+			})
+		);
 	}
 
 	return callback(null, true);

--- a/lib/winston-azure-application-insights.js
+++ b/lib/winston-azure-application-insights.js
@@ -73,6 +73,14 @@ var AzureApplicationInsightsLogger = function (options) {
 	this.silent = options.silent || DEFAULT_IS_SILENT;
 	this.treatErrorsAsExceptions = !!options.treatErrorsAsExceptions;
 
+	if (typeof options.formatter === 'function') {
+		this.formatter = options.formatter;
+	} else {
+		this.formatter = function noopFormatter(msg) {
+			return msg;
+		};
+	}
+
 	// Setup AI here!
 };
 
@@ -131,8 +139,7 @@ AzureApplicationInsightsLogger.prototype.log = function (level, msg, meta, callb
 			properties: properties,
 		});
 	}
-	else
-	{
+	else {
 		if (meta instanceof Error) {
 			var errorMeta = {
 				stack: meta.stack,
@@ -140,7 +147,7 @@ AzureApplicationInsightsLogger.prototype.log = function (level, msg, meta, callb
 			};
 
 			for (var field in meta) {
-				if(field === 'message' && !msg) {
+				if (field === 'message' && !msg) {
 					msg = meta[field];
 					continue;
 				} else if (field === 'constructor') {
@@ -152,8 +159,9 @@ AzureApplicationInsightsLogger.prototype.log = function (level, msg, meta, callb
 
 			meta = errorMeta;
 		}
+
 		this.client.trackTrace({
-			message: msg,
+			message: this.formatter(msg),
 			severity: aiLevel,
 			properties: meta,
 		});

--- a/test/winston-azure-application-insights.test.js
+++ b/test/winston-azure-application-insights.test.js
@@ -119,7 +119,7 @@ describe ('winston-azure-application-insights', function() {
 					key: 'FAKEKEY'
 				});
 
-				assert.ok(winston.transports.AzureApplicationInsightsLogger);
+				assert.ok(transport.AzureApplicationInsightsLogger);
 			});
 		});
 
@@ -278,7 +278,7 @@ describe ('winston-azure-application-insights', function() {
 			var freshClient = new appInsights.TelemetryClient('FAKEKEY');
 
 			winstonLogger = new(winston.Logger)({
-				transports: [ new winston.transports.AzureApplicationInsightsLogger({ client: freshClient })	]
+				transports: [ new transport.AzureApplicationInsightsLogger({ client: freshClient })	]
 			});
 
 			clientMock = sinon.mock(freshClient);

--- a/test/winston-azure-application-insights.test.js
+++ b/test/winston-azure-application-insights.test.js
@@ -343,5 +343,40 @@ describe ('winston-azure-application-insights', function() {
 
 			winstonLogger.error(message, error);
 		});
+
+		describe('formatter', function() {
+
+			var winstonLogger,
+				clientMock,
+				expectTrace;
+
+			beforeEach(function() {
+				var freshClient = new appInsights.TelemetryClient('FAKEKEY');
+				winstonLogger = new(winston.Logger)({
+					transports: [
+						new winston.transports.AzureApplicationInsightsLogger({
+							client: freshClient,
+							formatter: (level, message) => `${level}-${message}`,
+						}),
+					],
+				});
+				clientMock = sinon.mock(freshClient);
+				expectTrace = clientMock.expects("trackTrace");
+			});
+
+			afterEach(function() {
+				clientMock.restore();
+			});
+
+			it('should log from winston with a formatter', function() {
+				var logMessage = "some log text...",
+					logLevel = 'debug';
+
+				expectTrace.once().withExactArgs(`${logLevel}-${logMessage}`, 0, {});
+
+				winstonLogger.log(logLevel, logMessage);
+			});
+		});
 	});
+
 });

--- a/test/winston-azure-application-insights.test.js
+++ b/test/winston-azure-application-insights.test.js
@@ -407,4 +407,13 @@ describe ('winston-azure-application-insights', function() {
 		});
 	});
 
+	describe('exports', function () {
+		it('exposes defaultFormatter', function () {
+			assert.isFunction(transport.defaultFormatter);
+		});
+		it('exposes getMessageLevel', function () {
+			assert.isFunction(transport.getMessageLevel);
+		});
+	});
+
 });


### PR DESCRIPTION
Closes #6, #7

Formatter support so that the objects passed to `trackTrace` and `trackException` can be modified in userland.

Follows on from the work done by @fdescamps - thanks, and sorry for the wait.