### PR TITLE
FIX Use appInsights explicit log levels

### DIFF
--- a/lib/winston-azure-application-insights.js
+++ b/lib/winston-azure-application-insights.js
@@ -12,22 +12,19 @@ var DEFAULT_IS_SILENT = false;
 
 // Remaping winston level on Application Insights 
 function getMessageLevel(winstonLevel) {
-	
-	// TODO: Find a way to get the actual level values from AI's SDK
-	// They are defined in SDK's "Library/Contracts.ts"
-	 
+
 	var levels = {
-		emerg: 4,	// AI 'Critical' 
-		alert: 4,	// AI 'Critical' 
-		crit: 4,	// AI 'Critical' 
-		error: 3,	// AI 'Error' 
-		warning: 2,	// AI 'Warning' 
-		warn:  2,	// AI 'Warning'
-		notice: 1,	// AI 'Informational'
-		info: 1,	// AI 'Informational'
-		verbose: 0,	// AI 'Verbose'
-		debug: 0,	// AI 'Verbose'
-		silly: 0	// AI 'Verbose'
+		emerg: appInsights.Contracts.SeverityLevel.Critical,
+		alert: appInsights.Contracts.SeverityLevel.Critical,
+		crit: appInsights.Contracts.SeverityLevel.Critical,
+		error: appInsights.Contracts.SeverityLevel.Error,
+		warning: appInsights.Contracts.SeverityLevel.Warning,
+		warn:  appInsights.Contracts.SeverityLevel.Warning,
+		notice: appInsights.Contracts.SeverityLevel.Information,
+		info: appInsights.Contracts.SeverityLevel.Information,
+		verbose: appInsights.Contracts.SeverityLevel.Verbose,
+		debug: appInsights.Contracts.SeverityLevel.Verbose,
+		silly: appInsights.Contracts.SeverityLevel.Verbose
 	};
 	 
 	return winstonLevel in levels ? levels[winstonLevel] : levels.info; 


### PR DESCRIPTION
This completes a `@todo` as outlined in the code.

See: https://docs.microsoft.com/en-us/azure/application-insights/app-insights-api-custom-events-metrics#tracktrace for details on how to access the log level constants